### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,9 +17,25 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  #   @item = @item.includes(:user)
-  #   redirect_to item_path(id: current_user)
+  def show
+    @item = Item.find(params[:id])
+    # @user = User.new
+  end
+
+  # def edit
+  #   @item = Item.find(params[:id])
+  # end
+
+  # def update
+  #   item = Item.find(params[:id])
+  #   item.update(item_params)
+  #   redirect_to root_path
+  # end
+
+  # def destroy
+  #   item = Item.find(params[:id])
+  #   item.destroy
+  #   redirect_to root_path
   # end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :item_tweet, only: [:show]
+
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -18,8 +20,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
-    # @user = User.new
   end
 
   # def edit
@@ -43,4 +43,9 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:image, :name, :description, :category_id, :condition_id, :delivery_fee_id, :state_id, :day_id, :price).merge(user_id: current_user.id)
   end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,10 +126,35 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
       <li class='list'>
-        <%= item_lists(@items) %>
+         <% @items.each do |item| %>
+          <%= link_to item_path(item) do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
+
+            <%# 商品が売れていればsold outの表示 %>
+            <%# if item.item_purchase != nil %>
+              <%# <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div> %>
+            <%# end %>
+            <%# //商品が売れていればsold outの表示 %>
+
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        <% end %>
       </li>
-     
-        
     </ul>
   </div>
 <div class='purchase-btn'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,37 +126,60 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
       <li class='list'>
-         <% @items.each do |item| %>
-          <%= link_to item_path(item) do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %>
 
-            <%# 商品が売れていればsold outの表示 %>
-            <%# if item.item_purchase != nil %>
-              <%# <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div> %>
-            <%# end %>
-            <%# //商品が売れていればsold outの表示 %>
+          <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag "item-sample.png", class: "item-img" %>
 
+          <%# 商品が売れていればsold outの表示 %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
           </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= item.name %>
-            </h3>
-            <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
+          <%# //商品が売れていればsold outの表示 %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= "商品名" %>
+          </h3>
+          <div class='item-price'>
+            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
             </div>
           </div>
-          <% end %>
+        </div>
         <% end %>
       </li>
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+      <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# //商品がない場合のダミー %>
     </ul>
   </div>
+  <%# //商品一覧 %>
+</div>
+
 <div class='purchase-btn'>
 <% if user_signed_in? %>
   <%= link_to new_item_path, target: "_blank" do %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,65 +4,64 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag (@item.image) ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+      <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%# ログインしているユーザと出品しているユーザが同一人物である時%>
+    <% if user_signed_in? && current_user.id == @item.user.id %>
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
-
+    <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -101,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,4 @@ Rails.application.routes.draw do
   root to: 'items#index'
   resources :items
   resources :users
-
-
 end


### PR DESCRIPTION
#What
①ブランチの作成（商品詳細表示機能の実装）
②商品詳細表示機能の実装↓
1. [ログアウト状態でも商品詳細ページを閲覧できる](https://gyazo.com/6fa3a9a24e875327f880d3301f1ce5a2
)
2.出品者にしか商品の編集・削除のリンクが踏めないようになっている
 [(表示がされる)](https://gyazo.com/0a016fc4a83d6be419713aa977f8057c)
 [(編集リンクが踏める)](https://gyazo.com/41bf01320a6c31c02f58ad832beb6fef   )
 [(削除リンクが踏める）](https://gyazo.com/43a6bb9d8df4a8c8ae0c4203302a6418)
[3.出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏める](https://gyazo.com/e6c19a956a536d7399365258eafe0537)
[4.商品出品時に登録した情報が見られるようになっている](https://gyazo.com/f71ce04781ccbe956a4e29f9db860fd1)
5.画像が表示されており、画像がリンク切れなどになっていない

#Why
商品詳細表示機能の実装のため

※商品の編集・削除について、gyazogifで動かしておりますが、次からの実装条件と被る部分であったため、
 機能ごとの表示をさせるためにitems_controllerのコードをコメントアウトしています。

どうぞよろしくお願いいたします。